### PR TITLE
Default sns message size used for threshold in case withAlwaysThrough…

### DIFF
--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedClient.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedClient.java
@@ -37,7 +37,7 @@ public class AmazonSNSExtendedClient extends AmazonSNSExtendedClientBase {
     public AmazonSNSExtendedClient(AmazonSNS snsClient, SNSExtendedClientConfiguration snsExtendedClientConfiguration) {
         super(snsClient);
 
-        this.snsExtendedClientConfiguration = new SNSExtendedClientConfiguration(snsExtendedClientConfiguration);
+        this.snsExtendedClientConfiguration = snsExtendedClientConfiguration;
         S3Dao s3Dao = new S3Dao(this.snsExtendedClientConfiguration.getAmazonS3Client());
         this.payloadStore = new S3BackedPayloadStore(s3Dao, this.snsExtendedClientConfiguration.getS3BucketName());
     }

--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
@@ -13,8 +13,6 @@ import com.amazonaws.services.sns.model.*;
 import java.util.List;
 
 abstract class AmazonSNSExtendedClientBase implements AmazonSNS {
-    static final int SNS_DEFAULT_MESSAGE_SIZE = 262144;
-
     private final AmazonSNS amazonSNSToBeExtended;
 
     public AmazonSNSExtendedClientBase(AmazonSNS amazonSNSToBeExtended) {

--- a/src/main/java/software/amazon/sns/SNSExtendedClientConfiguration.java
+++ b/src/main/java/software/amazon/sns/SNSExtendedClientConfiguration.java
@@ -5,10 +5,11 @@ import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import software.amazon.payloadoffloading.PayloadStorageConfiguration;
 
 public class SNSExtendedClientConfiguration extends PayloadStorageConfiguration {
+    static final int SNS_DEFAULT_MESSAGE_SIZE = 262144;
 
     public SNSExtendedClientConfiguration() {
         super();
-        setPayloadSizeThreshold(AmazonSNSExtendedClientBase.SNS_DEFAULT_MESSAGE_SIZE);
+        setPayloadSizeThreshold(SNS_DEFAULT_MESSAGE_SIZE);
     }
 
     public SNSExtendedClientConfiguration(SNSExtendedClientConfiguration snsExtendedClientConfiguration) {

--- a/src/test/java/software/amazon/sns/AmazonSNSExtendedClientTest.java
+++ b/src/test/java/software/amazon/sns/AmazonSNSExtendedClientTest.java
@@ -28,8 +28,8 @@ public class AmazonSNSExtendedClientTest {
     private static final String S3_BUCKET_NAME = "test-bucket-name";
     private static final String SNS_TOPIC_ARN = "test-topic-arn";
     private static final int LESS_THAN_SNS_SIZE_LIMIT = 3;
-    private static final int MORE_THAN_SNS_SIZE_LIMIT = AmazonSNSExtendedClient.SNS_DEFAULT_MESSAGE_SIZE + 1;
-    // should be > 1 and << AmazonSNSExtendedClient.SNS_DEFAULT_MESSAGE_SIZE
+    private static final int MORE_THAN_SNS_SIZE_LIMIT = SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE + 1;
+    // should be > 1 and << SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE
     private static final int ARBITRARY_SMALLER_THRESHOLD = 500;
 
     private AmazonSNS extendedSnsWithDefaultConfig;
@@ -44,7 +44,7 @@ public class AmazonSNSExtendedClientTest {
 
         SNSExtendedClientConfiguration snsExtendedClientConfiguration = new SNSExtendedClientConfiguration()
                 .withPayloadSupportEnabled(mockS3, S3_BUCKET_NAME)
-                .withPayloadSizeThreshold(AmazonSNSExtendedClient.SNS_DEFAULT_MESSAGE_SIZE);
+                .withPayloadSizeThreshold(SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE);
 
         extendedSnsWithDefaultConfig = spy(new AmazonSNSExtendedClient(mockSnsBackend, snsExtendedClientConfiguration));
     }
@@ -68,7 +68,7 @@ public class AmazonSNSExtendedClientTest {
 
     @Test
     public void testPublishSmallMessageS3IsNotUsed() {
-        String messageBody = generateStringWithLength(AmazonSNSExtendedClient.SNS_DEFAULT_MESSAGE_SIZE);
+        String messageBody = generateStringWithLength(SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE);
 
         PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
         extendedSnsWithDefaultConfig.publish(publishRequest);
@@ -231,7 +231,7 @@ public class AmazonSNSExtendedClientTest {
 
     @Test
     public void testThrowAmazonClientExceptionWhenSizeOfMessageAttributeKeyIsLargerThanThreshold() {
-        String messageBody = generateStringWithLength(AmazonSNSExtendedClient.SNS_DEFAULT_MESSAGE_SIZE);
+        String messageBody = generateStringWithLength(SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE);
         String attributeKey = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
         String attributeValue = generateStringWithLength(LESS_THAN_SNS_SIZE_LIMIT);
 
@@ -249,14 +249,14 @@ public class AmazonSNSExtendedClientTest {
 
         } catch (AmazonClientException exception) {
             Assert.assertTrue(exception.getMessage().contains("Total size of Message attributes is "
-                    + expectedSize + " bytes which is larger than the threshold of " + AmazonSNSExtendedClient.SNS_DEFAULT_MESSAGE_SIZE
+                    + expectedSize + " bytes which is larger than the threshold of " + SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE
                     + " Bytes. Consider including the payload in the message body instead of message attributes."));
         }
     }
 
     @Test
     public void testThrowAmazonClientExceptionWhenSizeOfMessageAttributeValueIsLargerThanThreshold() {
-        String messageBody = generateStringWithLength(AmazonSNSExtendedClient.SNS_DEFAULT_MESSAGE_SIZE);
+        String messageBody = generateStringWithLength(SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE);
         String attributeKey = generateStringWithLength(LESS_THAN_SNS_SIZE_LIMIT);
         String attributeValue = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
 
@@ -274,7 +274,7 @@ public class AmazonSNSExtendedClientTest {
 
         } catch (AmazonClientException exception) {
             Assert.assertTrue(exception.getMessage().contains("Total size of Message attributes is "
-                    + expectedSize + " bytes which is larger than the threshold of " + AmazonSNSExtendedClient.SNS_DEFAULT_MESSAGE_SIZE
+                    + expectedSize + " bytes which is larger than the threshold of " + SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE
                     + " Bytes. Consider including the payload in the message body instead of message attributes."));
         }
     }


### PR DESCRIPTION
…S3(true) is set on PayloadStorageConfiguration

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
