### PR TITLE
Bump payloadoffloading-common version from 1.1.0 to 1.1.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>software.amazon.payloadoffloading</groupId>
             <artifactId>payloadoffloading-common</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/src/test/java/software/amazon/sns/AmazonSNSExtendedClientTest.java
+++ b/src/test/java/software/amazon/sns/AmazonSNSExtendedClientTest.java
@@ -67,6 +67,26 @@ public class AmazonSNSExtendedClientTest {
     }
 
     @Test
+    public void testPublishLargeMessageS3IsUsedWithS3Key() {
+        String messageBody = generateStringWithLength(MORE_THAN_SNS_SIZE_LIMIT);
+
+        PublishRequest publishRequest = new PublishRequest(SNS_TOPIC_ARN, messageBody);
+        HashMap<String, MessageAttributeValue> attrs = new HashMap<>();
+        attrs.put("S3Key", new MessageAttributeValue().withStringValue("value"));
+        publishRequest.setMessageAttributes(attrs);
+        extendedSnsWithDefaultConfig.publish(publishRequest);
+
+        verify(mockS3, times(1)).putObject(any(PutObjectRequest.class));
+        ArgumentCaptor<PublishRequest> publishRequestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+        verify(mockSnsBackend, times(1)).publish(publishRequestCaptor.capture());
+
+        Map<String, MessageAttributeValue> attributes = publishRequestCaptor.getValue().getMessageAttributes();
+        Assert.assertEquals("Number", attributes.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME).getDataType());
+
+        Assert.assertEquals(messageBody.length(), (int) Integer.valueOf(attributes.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME).getStringValue()));
+    }
+
+    @Test
     public void testPublishSmallMessageS3IsNotUsed() {
         String messageBody = generateStringWithLength(SNSExtendedClientConfiguration.SNS_DEFAULT_MESSAGE_SIZE);
 


### PR DESCRIPTION
This bumping will help the customers to configure the s3 key values while publishing the request.
So that customers can store publish request at the location/S3Key passed in the publish request.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
