### PR TITLE
Add S3 Async Client support for SNS extended client

### DIFF
--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedAsyncClient.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedAsyncClient.java
@@ -1,0 +1,185 @@
+package software.amazon.sns;
+
+import com.amazon.sqs.javamessaging.SQSExtendedClientConstants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.sns.SnsAsyncClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.payloadoffloading.PayloadStoreAsync;
+import software.amazon.payloadoffloading.S3AsyncDao;
+import software.amazon.payloadoffloading.S3BackedPayloadStoreAsync;
+import software.amazon.payloadoffloading.Util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static software.amazon.sns.AmazonSNSExtendedClientUtil.checkMessageAttributes;
+import static software.amazon.sns.AmazonSNSExtendedClientUtil.checkSizeOfMessageAttributes;
+import static software.amazon.sns.AmazonSNSExtendedClientUtil.getMessageAttributeSize;
+import static software.amazon.sns.AmazonSNSExtendedClientUtil.getMsgAttributesSize;
+import static software.amazon.sns.AmazonSNSExtendedClientUtil.getS3keyAttribute;
+import static software.amazon.sns.AmazonSNSExtendedClientUtil.isTotalMessageSizeLargerThanThreshold;
+import static software.amazon.sns.SNSExtendedClientConstants.MULTIPLE_PROTOCOL_MESSAGE_STRUCTURE;
+import static software.amazon.sns.SNSExtendedClientConstants.USER_AGENT_HEADER_NAME;
+
+public class AmazonSNSExtendedAsyncClient extends AmazonSNSExtendedAsyncClientBase implements SnsAsyncClient {
+
+    static final String USER_AGENT_HEADER = Util.getUserAgentHeader(AmazonSNSExtendedAsyncClient.class.getSimpleName());
+    private static final Log LOGGER = LogFactory.getLog(AmazonSNSExtendedAsyncClient.class);
+    private SNSExtendedAsyncClientConfiguration snsExtendedClientConfiguration;
+    private PayloadStoreAsync payloadStore;
+
+    /**
+     * Constructs a new Amazon SNS extended client to invoke service methods on
+     * Amazon SNS with extended functionality using the specified Amazon SNS
+     * client object.
+     *
+     * <p>
+     * All service calls made using this client are asynchronous, and will return
+     * immediately with a {@link CompletableFuture} that completes when the operation
+     * completes or when an exception is thrown. Argument validation exception are thrown
+     * immediately, and not through the future.
+     * </p>
+     *
+     * @param snsClient
+     *              The Amazon SNS client to use to connect to Amazon SNS.
+     */
+    public AmazonSNSExtendedAsyncClient(SnsAsyncClient snsClient) {
+        this(snsClient, new SNSExtendedAsyncClientConfiguration());
+    }
+
+    /**
+     * Constructs a new Amazon SNS extended client to invoke service methods on
+     * Amazon SNS with extended functionality using the specified Amazon SNS
+     * client object.
+     *
+     * <p>
+     * All service calls made using this client are asynchronous, and will return
+     * immediately with a {@link CompletableFuture} that completes when the operation
+     * completes or when an exception is thrown. Argument validation exceptions are thrown
+     * immediately, and not through the future.
+     * </p>
+     *
+     * @param snsClient
+     *            The Amazon SNS async client to use to connect to Amazon SNS.
+     * @param clientConfig
+     *            The extended client configuration options controlling the
+     *            functionality of this client.
+     */
+    public AmazonSNSExtendedAsyncClient(SnsAsyncClient snsClient, SNSExtendedAsyncClientConfiguration clientConfig) {
+        super(snsClient);
+        this.snsExtendedClientConfiguration = new SNSExtendedAsyncClientConfiguration(clientConfig);
+        S3AsyncDao s3Dao = new S3AsyncDao(snsExtendedClientConfiguration.getS3AsyncClient());
+        this.payloadStore = new S3BackedPayloadStoreAsync(s3Dao, snsExtendedClientConfiguration.getS3BucketName());
+    }
+
+    /**
+     * Constructs a new Amazon SNS extended client to invoke service methods on
+     * Amazon SNS with extended functionality using the specified Amazon SNS
+     * client object and Payload Store object.
+     * <p>
+     * All service calls made using this client are asynchronous, and will return
+     * immediately with a {@link CompletableFuture} that completes when the operation
+     * completes or when an exception is thrown. Argument validation exceptions are thrown
+     * immediately, and not through the future.
+     * </p>
+     *
+     * @param snsClient                   The Amazon SNS client to use to connect to Amazon SNS.
+     * @param clientConfig The sns extended client configuration options controlling the
+     *                                    functionality of this client.
+     * @param payloadStore                The Payload Store that handles logic for saving to the desired
+     *                                    extended storage.
+     */
+    public AmazonSNSExtendedAsyncClient(SnsAsyncClient snsClient, SNSExtendedAsyncClientConfiguration clientConfig,
+                                        PayloadStoreAsync payloadStore) {
+        super(snsClient);
+
+        this.snsExtendedClientConfiguration = clientConfig;
+        this.payloadStore = payloadStore;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<PublishResponse> publish(PublishRequest publishRequest) throws S3Exception {
+        if (publishRequest == null || StringUtils.isEmpty(publishRequest.message())) {
+            return super.publish(publishRequest);
+        }
+
+        if (!StringUtils.isEmpty(publishRequest.messageStructure()) &&
+                publishRequest.messageStructure().equals(MULTIPLE_PROTOCOL_MESSAGE_STRUCTURE)) {
+            String errorMessage = "SNS extended client does not support sending JSON messages.";
+            LOGGER.error(errorMessage);
+            throw SdkClientException.create(errorMessage);
+        }
+
+        PublishRequest.Builder publishRequestBuilder = publishRequest.toBuilder();
+        publishRequestBuilder.overrideConfiguration(AwsRequestOverrideConfiguration.builder().putHeader(USER_AGENT_HEADER_NAME, USER_AGENT_HEADER).build());
+        publishRequest = publishRequestBuilder.build();
+
+        long messageAttributesSize = getMsgAttributesSize(publishRequest.messageAttributes());
+        long messageBodySize = Util.getStringSizeInBytes(publishRequest.message());
+
+        if (!shouldExtendedStoreBeUsed(messageAttributesSize + messageBodySize)) {
+            return super.publish(publishRequest);
+        }
+
+        checkMessageAttributes(publishRequest.messageAttributes());
+        checkSizeOfMessageAttributes(snsExtendedClientConfiguration.getPayloadSizeThreshold(), messageAttributesSize);
+
+        PublishRequest clonedPublishRequest = copyPublishRequest(publishRequest);
+
+        return storeMessageInExtendedStore(clonedPublishRequest, messageAttributesSize).thenCompose(super::publish);
+    }
+
+    private CompletableFuture<PublishRequest> storeMessageInExtendedStore(PublishRequest publishRequest, long messageAttributeSize) throws S3Exception {
+        String messageContentStr = publishRequest.message();
+        long messageContentSize = Util.getStringSizeInBytes(messageContentStr);
+        String s3Key = getS3keyAttribute(publishRequest.messageAttributes());
+
+        PublishRequest.Builder publishRequestBuilder = publishRequest.toBuilder();
+
+        MessageAttributeValue.Builder messageAttributeValueBuilder = MessageAttributeValue.builder();
+        messageAttributeValueBuilder.dataType("Number");
+        messageAttributeValueBuilder.stringValue(String.valueOf(messageContentSize));
+        MessageAttributeValue messageAttributeValue = messageAttributeValueBuilder.build();
+
+        Map<String, MessageAttributeValue> attributes = new HashMap<>(publishRequest.messageAttributes());
+        attributes.put(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME, messageAttributeValue);
+        publishRequestBuilder.messageAttributes(attributes);
+
+        messageAttributeSize += getMessageAttributeSize(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME, messageAttributeValue);
+        checkSizeOfMessageAttributes(snsExtendedClientConfiguration.getPayloadSizeThreshold(), messageAttributeSize);
+
+        CompletableFuture<String> largeMessagePointerFuture = (s3Key != null)? payloadStore.storeOriginalPayload(messageContentStr, s3Key): payloadStore.storeOriginalPayload(messageContentStr);
+
+        return largeMessagePointerFuture.thenApply(largeMessagePointer -> {
+            publishRequestBuilder.message(largeMessagePointer);
+            return publishRequestBuilder.build();
+        });
+    }
+
+    private PublishRequest copyPublishRequest(PublishRequest publishRequest) {
+        // We only modify Message and MessageAttributes, to avoid performance impact, let's shallow-copy
+        // the request and then copy the MessageAttributes map.
+        PublishRequest.Builder publishRequestBuilder = publishRequest.toBuilder();
+        Map<String, MessageAttributeValue> attributes = new HashMap<>(publishRequest.messageAttributes());
+        publishRequestBuilder.messageAttributes(attributes);
+        return publishRequestBuilder.build();
+    }
+
+    private boolean shouldExtendedStoreBeUsed(long totalMessageSize) {
+        return snsExtendedClientConfiguration.isAlwaysThroughS3() ||
+                (snsExtendedClientConfiguration.isPayloadSupportEnabled() &&
+                        isTotalMessageSizeLargerThanThreshold(
+                                snsExtendedClientConfiguration.getPayloadSizeThreshold(),totalMessageSize));
+    }
+}

--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedAsyncClientBase.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedAsyncClientBase.java
@@ -1,0 +1,408 @@
+package software.amazon.sns;
+
+import software.amazon.awssdk.services.sns.SnsAsyncClient;
+import software.amazon.awssdk.services.sns.model.AddPermissionRequest;
+import software.amazon.awssdk.services.sns.model.AddPermissionResponse;
+import software.amazon.awssdk.services.sns.model.CheckIfPhoneNumberIsOptedOutRequest;
+import software.amazon.awssdk.services.sns.model.CheckIfPhoneNumberIsOptedOutResponse;
+import software.amazon.awssdk.services.sns.model.ConfirmSubscriptionRequest;
+import software.amazon.awssdk.services.sns.model.ConfirmSubscriptionResponse;
+import software.amazon.awssdk.services.sns.model.CreatePlatformApplicationRequest;
+import software.amazon.awssdk.services.sns.model.CreatePlatformApplicationResponse;
+import software.amazon.awssdk.services.sns.model.CreatePlatformEndpointRequest;
+import software.amazon.awssdk.services.sns.model.CreatePlatformEndpointResponse;
+import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
+import software.amazon.awssdk.services.sns.model.CreateTopicResponse;
+import software.amazon.awssdk.services.sns.model.DeleteEndpointRequest;
+import software.amazon.awssdk.services.sns.model.DeleteEndpointResponse;
+import software.amazon.awssdk.services.sns.model.DeletePlatformApplicationRequest;
+import software.amazon.awssdk.services.sns.model.DeletePlatformApplicationResponse;
+import software.amazon.awssdk.services.sns.model.DeleteTopicRequest;
+import software.amazon.awssdk.services.sns.model.DeleteTopicResponse;
+import software.amazon.awssdk.services.sns.model.GetEndpointAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetEndpointAttributesResponse;
+import software.amazon.awssdk.services.sns.model.GetPlatformApplicationAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetPlatformApplicationAttributesResponse;
+import software.amazon.awssdk.services.sns.model.GetSmsAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetSmsAttributesResponse;
+import software.amazon.awssdk.services.sns.model.GetSubscriptionAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetSubscriptionAttributesResponse;
+import software.amazon.awssdk.services.sns.model.GetTopicAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetTopicAttributesResponse;
+import software.amazon.awssdk.services.sns.model.ListEndpointsByPlatformApplicationRequest;
+import software.amazon.awssdk.services.sns.model.ListEndpointsByPlatformApplicationResponse;
+import software.amazon.awssdk.services.sns.model.ListPhoneNumbersOptedOutRequest;
+import software.amazon.awssdk.services.sns.model.ListPhoneNumbersOptedOutResponse;
+import software.amazon.awssdk.services.sns.model.ListPlatformApplicationsRequest;
+import software.amazon.awssdk.services.sns.model.ListPlatformApplicationsResponse;
+import software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicRequest;
+import software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicResponse;
+import software.amazon.awssdk.services.sns.model.ListSubscriptionsRequest;
+import software.amazon.awssdk.services.sns.model.ListSubscriptionsResponse;
+import software.amazon.awssdk.services.sns.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.sns.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.sns.model.ListTopicsRequest;
+import software.amazon.awssdk.services.sns.model.ListTopicsResponse;
+import software.amazon.awssdk.services.sns.model.OptInPhoneNumberRequest;
+import software.amazon.awssdk.services.sns.model.OptInPhoneNumberResponse;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+import software.amazon.awssdk.services.sns.model.RemovePermissionRequest;
+import software.amazon.awssdk.services.sns.model.RemovePermissionResponse;
+import software.amazon.awssdk.services.sns.model.SetEndpointAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetEndpointAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SetPlatformApplicationAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetPlatformApplicationAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SetSmsAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetSmsAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SetSubscriptionAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetSubscriptionAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SetTopicAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetTopicAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SubscribeRequest;
+import software.amazon.awssdk.services.sns.model.SubscribeResponse;
+import software.amazon.awssdk.services.sns.model.TagResourceRequest;
+import software.amazon.awssdk.services.sns.model.TagResourceResponse;
+import software.amazon.awssdk.services.sns.model.UnsubscribeRequest;
+import software.amazon.awssdk.services.sns.model.UnsubscribeResponse;
+import software.amazon.awssdk.services.sns.model.UntagResourceRequest;
+import software.amazon.awssdk.services.sns.model.UntagResourceResponse;
+import software.amazon.awssdk.services.sns.paginators.ListEndpointsByPlatformApplicationPublisher;
+import software.amazon.awssdk.services.sns.paginators.ListPlatformApplicationsPublisher;
+import software.amazon.awssdk.services.sns.paginators.ListSubscriptionsByTopicPublisher;
+import software.amazon.awssdk.services.sns.paginators.ListSubscriptionsPublisher;
+import software.amazon.awssdk.services.sns.paginators.ListTopicsPublisher;
+
+import java.util.concurrent.CompletableFuture;
+
+public abstract class AmazonSNSExtendedAsyncClientBase implements SnsAsyncClient {
+    private final SnsAsyncClient snsClientToBeExtended;
+
+    public AmazonSNSExtendedAsyncClientBase(SnsAsyncClient snsClientToBeExtended) {
+        this.snsClientToBeExtended = snsClientToBeExtended;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<GetEndpointAttributesResponse> getEndpointAttributes(
+            GetEndpointAttributesRequest getEndpointAttributesRequest) {
+        return snsClientToBeExtended.getEndpointAttributes(getEndpointAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<AddPermissionResponse> addPermission(AddPermissionRequest addPermissionRequest) {
+        return snsClientToBeExtended.addPermission(addPermissionRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<CheckIfPhoneNumberIsOptedOutResponse> checkIfPhoneNumberIsOptedOut(
+            CheckIfPhoneNumberIsOptedOutRequest checkIfPhoneNumberIsOptedOutRequest) {
+        return snsClientToBeExtended.checkIfPhoneNumberIsOptedOut(checkIfPhoneNumberIsOptedOutRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<ConfirmSubscriptionResponse> confirmSubscription(ConfirmSubscriptionRequest confirmSubscriptionRequest) {
+        return snsClientToBeExtended.confirmSubscription(confirmSubscriptionRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<CreatePlatformApplicationResponse> createPlatformApplication(CreatePlatformApplicationRequest createPlatformApplicationRequest) {
+        return snsClientToBeExtended.createPlatformApplication(createPlatformApplicationRequest);
+    }
+
+    @Override
+    public CompletableFuture<CreatePlatformEndpointResponse> createPlatformEndpoint(CreatePlatformEndpointRequest createPlatformEndpointRequest) {
+        return  snsClientToBeExtended.createPlatformEndpoint(createPlatformEndpointRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<CreateTopicResponse> createTopic(CreateTopicRequest createTopicRequest) {
+        return snsClientToBeExtended.createTopic(createTopicRequest);
+    }
+
+    @Override
+    public CompletableFuture<DeleteEndpointResponse> deleteEndpoint(DeleteEndpointRequest deleteEndpointRequest) {
+        return snsClientToBeExtended.deleteEndpoint(deleteEndpointRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<DeletePlatformApplicationResponse> deletePlatformApplication(
+            DeletePlatformApplicationRequest deletePlatformApplicationRequest) {
+        return snsClientToBeExtended.deletePlatformApplication(deletePlatformApplicationRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<DeleteTopicResponse> deleteTopic(DeleteTopicRequest deleteTopicRequest) {
+        return snsClientToBeExtended.deleteTopic(deleteTopicRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<GetPlatformApplicationAttributesResponse> getPlatformApplicationAttributes(
+            GetPlatformApplicationAttributesRequest getPlatformApplicationAttributesRequest) {
+        return snsClientToBeExtended.getPlatformApplicationAttributes(getPlatformApplicationAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<GetSmsAttributesResponse> getSMSAttributes(GetSmsAttributesRequest getSMSAttributesRequest) {
+        return snsClientToBeExtended.getSMSAttributes(getSMSAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<GetSubscriptionAttributesResponse> getSubscriptionAttributes(
+            GetSubscriptionAttributesRequest getSubscriptionAttributesRequest) {
+        return snsClientToBeExtended.getSubscriptionAttributes(getSubscriptionAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<GetTopicAttributesResponse> getTopicAttributes(GetTopicAttributesRequest getTopicAttributesRequest) {
+        return snsClientToBeExtended.getTopicAttributes(getTopicAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<ListEndpointsByPlatformApplicationResponse> listEndpointsByPlatformApplication(
+            ListEndpointsByPlatformApplicationRequest listEndpointsByPlatformApplicationRequest) {
+        return snsClientToBeExtended.listEndpointsByPlatformApplication(listEndpointsByPlatformApplicationRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ListEndpointsByPlatformApplicationPublisher listEndpointsByPlatformApplicationPaginator(
+            ListEndpointsByPlatformApplicationRequest listEndpointsByPlatformApplicationRequest) {
+        return snsClientToBeExtended.listEndpointsByPlatformApplicationPaginator(listEndpointsByPlatformApplicationRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<ListPhoneNumbersOptedOutResponse> listPhoneNumbersOptedOut(
+            ListPhoneNumbersOptedOutRequest listPhoneNumbersOptedOutRequest) {
+        return snsClientToBeExtended.listPhoneNumbersOptedOut(listPhoneNumbersOptedOutRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<ListPlatformApplicationsResponse> listPlatformApplications(
+            ListPlatformApplicationsRequest listPlatformApplicationsRequest) {
+        return snsClientToBeExtended.listPlatformApplications(listPlatformApplicationsRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ListPlatformApplicationsPublisher listPlatformApplicationsPaginator(
+            ListPlatformApplicationsRequest listPlatformApplicationsRequest) {
+        return snsClientToBeExtended.listPlatformApplicationsPaginator(listPlatformApplicationsRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<ListSubscriptionsResponse> listSubscriptions(ListSubscriptionsRequest listSubscriptionsRequest) {
+        return snsClientToBeExtended.listSubscriptions(listSubscriptionsRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ListSubscriptionsPublisher listSubscriptionsPaginator(ListSubscriptionsRequest listSubscriptionsRequest) {
+        return snsClientToBeExtended.listSubscriptionsPaginator(listSubscriptionsRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<ListSubscriptionsByTopicResponse> listSubscriptionsByTopic(
+            ListSubscriptionsByTopicRequest listSubscriptionsByTopicRequest) {
+        return snsClientToBeExtended.listSubscriptionsByTopic(listSubscriptionsByTopicRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ListSubscriptionsByTopicPublisher listSubscriptionsByTopicPaginator(
+            ListSubscriptionsByTopicRequest listSubscriptionsByTopicRequest) {
+        return snsClientToBeExtended.listSubscriptionsByTopicPaginator(listSubscriptionsByTopicRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<ListTopicsResponse> listTopics(ListTopicsRequest listTopicsRequest) {
+        return snsClientToBeExtended.listTopics(listTopicsRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ListTopicsPublisher listTopicsPaginator(ListTopicsRequest listTopicsRequest) {
+        return snsClientToBeExtended.listTopicsPaginator(listTopicsRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<OptInPhoneNumberResponse> optInPhoneNumber(OptInPhoneNumberRequest optInPhoneNumberRequest) {
+        return snsClientToBeExtended.optInPhoneNumber(optInPhoneNumberRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<PublishResponse> publish(PublishRequest publishRequest) {
+        return snsClientToBeExtended.publish(publishRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<RemovePermissionResponse> removePermission(RemovePermissionRequest removePermissionRequest) {
+        return snsClientToBeExtended.removePermission(removePermissionRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<SetEndpointAttributesResponse> setEndpointAttributes(
+            SetEndpointAttributesRequest setEndpointAttributesRequest) {
+        return snsClientToBeExtended.setEndpointAttributes(setEndpointAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<SetPlatformApplicationAttributesResponse> setPlatformApplicationAttributes(
+            SetPlatformApplicationAttributesRequest setPlatformApplicationAttributesRequest) {
+        return snsClientToBeExtended.setPlatformApplicationAttributes(setPlatformApplicationAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<SetSmsAttributesResponse> setSMSAttributes(SetSmsAttributesRequest setSMSAttributesRequest) {
+        return snsClientToBeExtended.setSMSAttributes(setSMSAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<SetSubscriptionAttributesResponse> setSubscriptionAttributes(
+            SetSubscriptionAttributesRequest setSubscriptionAttributesRequest) {
+        return snsClientToBeExtended.setSubscriptionAttributes(setSubscriptionAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<SetTopicAttributesResponse> setTopicAttributes(SetTopicAttributesRequest setTopicAttributesRequest) {
+        return snsClientToBeExtended.setTopicAttributes(setTopicAttributesRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<SubscribeResponse> subscribe(SubscribeRequest subscribeRequest) {
+        return snsClientToBeExtended.subscribe(subscribeRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<UnsubscribeResponse> unsubscribe(UnsubscribeRequest unsubscribeRequest) {
+        return snsClientToBeExtended.unsubscribe(unsubscribeRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<ListTagsForResourceResponse> listTagsForResource(
+            ListTagsForResourceRequest listTagsForResourceRequest) {
+        return snsClientToBeExtended.listTagsForResource(listTagsForResourceRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<TagResourceResponse> tagResource(TagResourceRequest tagResourceRequest) {
+        return snsClientToBeExtended.tagResource(tagResourceRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<UntagResourceResponse> untagResource(UntagResourceRequest untagResourceRequest) {
+        return snsClientToBeExtended.untagResource(untagResourceRequest);
+    }
+
+    @Override
+    public String serviceName() {
+        return snsClientToBeExtended.serviceName();
+    }
+
+    @Override
+    public void close() {
+        snsClientToBeExtended.close();
+    }
+}

--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedClientBase.java
@@ -1,9 +1,99 @@
 package software.amazon.sns;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.core.exception.*;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.sns.SnsClient;
-import software.amazon.awssdk.services.sns.model.*;
+import software.amazon.awssdk.services.sns.model.AddPermissionRequest;
+import software.amazon.awssdk.services.sns.model.AddPermissionResponse;
+import software.amazon.awssdk.services.sns.model.AuthorizationErrorException;
+import software.amazon.awssdk.services.sns.model.CheckIfPhoneNumberIsOptedOutRequest;
+import software.amazon.awssdk.services.sns.model.CheckIfPhoneNumberIsOptedOutResponse;
+import software.amazon.awssdk.services.sns.model.ConcurrentAccessException;
+import software.amazon.awssdk.services.sns.model.ConfirmSubscriptionRequest;
+import software.amazon.awssdk.services.sns.model.ConfirmSubscriptionResponse;
+import software.amazon.awssdk.services.sns.model.CreatePlatformApplicationRequest;
+import software.amazon.awssdk.services.sns.model.CreatePlatformApplicationResponse;
+import software.amazon.awssdk.services.sns.model.CreatePlatformEndpointRequest;
+import software.amazon.awssdk.services.sns.model.CreatePlatformEndpointResponse;
+import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
+import software.amazon.awssdk.services.sns.model.CreateTopicResponse;
+import software.amazon.awssdk.services.sns.model.DeleteEndpointRequest;
+import software.amazon.awssdk.services.sns.model.DeleteEndpointResponse;
+import software.amazon.awssdk.services.sns.model.DeletePlatformApplicationRequest;
+import software.amazon.awssdk.services.sns.model.DeletePlatformApplicationResponse;
+import software.amazon.awssdk.services.sns.model.DeleteTopicRequest;
+import software.amazon.awssdk.services.sns.model.DeleteTopicResponse;
+import software.amazon.awssdk.services.sns.model.EndpointDisabledException;
+import software.amazon.awssdk.services.sns.model.FilterPolicyLimitExceededException;
+import software.amazon.awssdk.services.sns.model.GetEndpointAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetEndpointAttributesResponse;
+import software.amazon.awssdk.services.sns.model.GetPlatformApplicationAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetPlatformApplicationAttributesResponse;
+import software.amazon.awssdk.services.sns.model.GetSmsAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetSmsAttributesResponse;
+import software.amazon.awssdk.services.sns.model.GetSubscriptionAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetSubscriptionAttributesResponse;
+import software.amazon.awssdk.services.sns.model.GetTopicAttributesRequest;
+import software.amazon.awssdk.services.sns.model.GetTopicAttributesResponse;
+import software.amazon.awssdk.services.sns.model.InternalErrorException;
+import software.amazon.awssdk.services.sns.model.InvalidParameterException;
+import software.amazon.awssdk.services.sns.model.InvalidParameterValueException;
+import software.amazon.awssdk.services.sns.model.InvalidSecurityException;
+import software.amazon.awssdk.services.sns.model.KmsAccessDeniedException;
+import software.amazon.awssdk.services.sns.model.KmsDisabledException;
+import software.amazon.awssdk.services.sns.model.KmsInvalidStateException;
+import software.amazon.awssdk.services.sns.model.KmsNotFoundException;
+import software.amazon.awssdk.services.sns.model.KmsOptInRequiredException;
+import software.amazon.awssdk.services.sns.model.KmsThrottlingException;
+import software.amazon.awssdk.services.sns.model.ListEndpointsByPlatformApplicationRequest;
+import software.amazon.awssdk.services.sns.model.ListEndpointsByPlatformApplicationResponse;
+import software.amazon.awssdk.services.sns.model.ListPhoneNumbersOptedOutRequest;
+import software.amazon.awssdk.services.sns.model.ListPhoneNumbersOptedOutResponse;
+import software.amazon.awssdk.services.sns.model.ListPlatformApplicationsRequest;
+import software.amazon.awssdk.services.sns.model.ListPlatformApplicationsResponse;
+import software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicRequest;
+import software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicResponse;
+import software.amazon.awssdk.services.sns.model.ListSubscriptionsRequest;
+import software.amazon.awssdk.services.sns.model.ListSubscriptionsResponse;
+import software.amazon.awssdk.services.sns.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.sns.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.sns.model.ListTopicsRequest;
+import software.amazon.awssdk.services.sns.model.ListTopicsResponse;
+import software.amazon.awssdk.services.sns.model.NotFoundException;
+import software.amazon.awssdk.services.sns.model.OptInPhoneNumberRequest;
+import software.amazon.awssdk.services.sns.model.OptInPhoneNumberResponse;
+import software.amazon.awssdk.services.sns.model.PlatformApplicationDisabledException;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+import software.amazon.awssdk.services.sns.model.RemovePermissionRequest;
+import software.amazon.awssdk.services.sns.model.RemovePermissionResponse;
+import software.amazon.awssdk.services.sns.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.sns.model.SetEndpointAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetEndpointAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SetPlatformApplicationAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetPlatformApplicationAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SetSmsAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetSmsAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SetSubscriptionAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetSubscriptionAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SetTopicAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SetTopicAttributesResponse;
+import software.amazon.awssdk.services.sns.model.SnsException;
+import software.amazon.awssdk.services.sns.model.StaleTagException;
+import software.amazon.awssdk.services.sns.model.SubscribeRequest;
+import software.amazon.awssdk.services.sns.model.SubscribeResponse;
+import software.amazon.awssdk.services.sns.model.SubscriptionLimitExceededException;
+import software.amazon.awssdk.services.sns.model.TagLimitExceededException;
+import software.amazon.awssdk.services.sns.model.TagPolicyException;
+import software.amazon.awssdk.services.sns.model.TagResourceRequest;
+import software.amazon.awssdk.services.sns.model.TagResourceResponse;
+import software.amazon.awssdk.services.sns.model.ThrottledException;
+import software.amazon.awssdk.services.sns.model.TopicLimitExceededException;
+import software.amazon.awssdk.services.sns.model.UnsubscribeRequest;
+import software.amazon.awssdk.services.sns.model.UnsubscribeResponse;
+import software.amazon.awssdk.services.sns.model.UntagResourceRequest;
+import software.amazon.awssdk.services.sns.model.UntagResourceResponse;
 import software.amazon.awssdk.services.sns.paginators.ListEndpointsByPlatformApplicationIterable;
 import software.amazon.awssdk.services.sns.paginators.ListPlatformApplicationsIterable;
 import software.amazon.awssdk.services.sns.paginators.ListSubscriptionsByTopicIterable;
@@ -53,7 +143,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * specified actions.
      * </p>
      *
-     * @param addPermissionRequest
+     * @param addPermissionRequest AddPermissionRequest object
      * @return Result of the AddPermission operation returned by the service.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
@@ -352,7 +442,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * does not result in an error.
      * </p>
      *
-     * @param deleteTopicRequest
+     * @param deleteTopicRequest DeleteTopicRequest Object
      * @return Result of the DeleteTopic operation returned by the service.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
@@ -547,7 +637,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * <br/>
      * <p>
      * This is a variant of
-     * {@link #listEndpointsByPlatformApplication(software.amazon.awssdk.services.sns.model.ListEndpointsByPlatformApplicationRequest)}
+     * {@link #listEndpointsByPlatformApplication(ListEndpointsByPlatformApplicationRequest)}
      * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
      * internally handle making service calls for you.
      * </p>
@@ -597,7 +687,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * </p>
      * <p>
      * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #listEndpointsByPlatformApplication(software.amazon.awssdk.services.sns.model.ListEndpointsByPlatformApplicationRequest)}
+     * {@link #listEndpointsByPlatformApplication(ListEndpointsByPlatformApplicationRequest)}
      * operation.</b>
      * </p>
      *
@@ -717,7 +807,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * <br/>
      * <p>
      * This is a variant of
-     * {@link #listPlatformApplications(software.amazon.awssdk.services.sns.model.ListPlatformApplicationsRequest)}
+     * {@link #listPlatformApplications(ListPlatformApplicationsRequest)}
      * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
      * internally handle making service calls for you.
      * </p>
@@ -767,7 +857,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * </p>
      * <p>
      * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #listPlatformApplications(software.amazon.awssdk.services.sns.model.ListPlatformApplicationsRequest)}
+     * {@link #listPlatformApplications(ListPlatformApplicationsRequest)}
      * operation.</b>
      * </p>
      *
@@ -840,7 +930,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * <br/>
      * <p>
      * This is a variant of
-     * {@link #listSubscriptions(software.amazon.awssdk.services.sns.model.ListSubscriptionsRequest)} operation. The
+     * {@link #listSubscriptions(ListSubscriptionsRequest)} operation. The
      * return type is a custom iterable that can be used to iterate through all the pages. SDK will internally handle
      * making service calls for you.
      * </p>
@@ -890,7 +980,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * </p>
      * <p>
      * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #listSubscriptions(software.amazon.awssdk.services.sns.model.ListSubscriptionsRequest)} operation.</b>
+     * {@link #listSubscriptions(ListSubscriptionsRequest)} operation.</b>
      * </p>
      *
      * @param listSubscriptionsRequest
@@ -964,7 +1054,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * <br/>
      * <p>
      * This is a variant of
-     * {@link #listSubscriptionsByTopic(software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicRequest)}
+     * {@link #listSubscriptionsByTopic(ListSubscriptionsByTopicRequest)}
      * operation. The return type is a custom iterable that can be used to iterate through all the pages. SDK will
      * internally handle making service calls for you.
      * </p>
@@ -1014,7 +1104,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * </p>
      * <p>
      * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #listSubscriptionsByTopic(software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicRequest)}
+     * {@link #listSubscriptionsByTopic(ListSubscriptionsByTopicRequest)}
      * operation.</b>
      * </p>
      *
@@ -1058,7 +1148,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * This action is throttled at 30 transactions per second (TPS).
      * </p>
      *
-     * @param listTopicsRequest
+     * @param listTopicsRequest ListTopicRequest Object
      * @return Result of the ListTopics operation returned by the service.
      * @throws InvalidParameterException   Indicates that a request parameter does not comply with the associated constraints.
      * @throws InternalErrorException      Indicates an internal service error.
@@ -1088,7 +1178,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * </p>
      * <br/>
      * <p>
-     * This is a variant of {@link #listTopics(software.amazon.awssdk.services.sns.model.ListTopicsRequest)} operation.
+     * This is a variant of {@link #listTopics(ListTopicsRequest)} operation.
      * The return type is a custom iterable that can be used to iterate through all the pages. SDK will internally
      * handle making service calls for you.
      * </p>
@@ -1137,10 +1227,10 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * </p>
      * <p>
      * <b>Note: If you prefer to have control on service calls, use the
-     * {@link #listTopics(software.amazon.awssdk.services.sns.model.ListTopicsRequest)} operation.</b>
+     * {@link #listTopics(ListTopicsRequest)} operation.</b>
      * </p>
      *
-     * @param listTopicsRequest
+     * @param listTopicsRequest ListTopicsRequest Object
      * @return A custom iterable that can be used to iterate through all the response pages.
      * @throws InvalidParameterException
      *         Indicates that a request parameter does not comply with the associated constraints.
@@ -1523,7 +1613,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Notification Service Developer Guide</i>.
      * </p>
      *
-     * @param listTagsForResourceRequest
+     * @param listTagsForResourceRequest ListTagsForResourceRequest Object
      * @return Result of the ListTagsForResource operation returned by the service.
      * @throws ResourceNotFoundException   Can't tag resource. Verify that the topic exists.
      * @throws TagPolicyException          The request doesn't comply with the IAM tag policy. Correct your request and then retry it.
@@ -1584,7 +1674,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * </li>
      * </ul>
      *
-     * @param tagResourceRequest
+     * @param tagResourceRequest TagResourceRequest Object
      * @return Result of the TagResource operation returned by the service.
      * @throws ResourceNotFoundException   Can't tag resource. Verify that the topic exists.
      * @throws TagLimitExceededException   Can't add more than 50 tags to a topic.
@@ -1615,7 +1705,7 @@ abstract class AmazonSNSExtendedClientBase implements SnsClient {
      * Guide</i>.
      * </p>
      *
-     * @param untagResourceRequest
+     * @param untagResourceRequest UntagResourceRequest Object
      * @return Result of the UntagResource operation returned by the service.
      * @throws ResourceNotFoundException   Can't tag resource. Verify that the topic exists.
      * @throws TagLimitExceededException   Can't add more than 50 tags to a topic.

--- a/src/main/java/software/amazon/sns/AmazonSNSExtendedClientUtil.java
+++ b/src/main/java/software/amazon/sns/AmazonSNSExtendedClientUtil.java
@@ -1,0 +1,89 @@
+package software.amazon.sns;
+
+import com.amazon.sqs.javamessaging.SQSExtendedClientConstants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.payloadoffloading.Util;
+
+import java.util.Map;
+
+public class AmazonSNSExtendedClientUtil {
+    private static final Log LOGGER = LogFactory.getLog(AmazonSNSExtendedClientUtil.class);
+    private static final String S3_KEY = "S3Key";
+
+
+    public static void checkMessageAttributes(Map<String, MessageAttributeValue> messageAttributes) {
+        int messageAttributesNum = messageAttributes.size();
+        if (messageAttributesNum > SQSExtendedClientConstants.MAX_ALLOWED_ATTRIBUTES) {
+            String errorMessage = "Number of message attributes [" + messageAttributesNum
+                    + "] exceeds the maximum allowed for large-payload messages ["
+                    + SQSExtendedClientConstants.MAX_ALLOWED_ATTRIBUTES + "].";
+            LOGGER.error(errorMessage);
+            throw SdkClientException.create(errorMessage);
+        }
+
+        MessageAttributeValue largePayloadAttributeName = messageAttributes.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME);
+
+        if (largePayloadAttributeName != null) {
+            String errorMessage = "Message attribute name " + SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME
+                    + " is reserved for use by SNS extended client.";
+            LOGGER.error(errorMessage);
+            throw SdkClientException.create(errorMessage);
+        }
+    }
+
+    public static void checkSizeOfMessageAttributes(int payloadSizeThreshold, long messageAttributeSize) {
+        if (messageAttributeSize > payloadSizeThreshold) {
+            String errorMessage = "Total size of Message attributes is " + messageAttributeSize
+                    + " bytes which is larger than the threshold of " + payloadSizeThreshold
+                    + " Bytes. Consider including the payload in the message body instead of message attributes.";
+            LOGGER.error(errorMessage);
+            throw SdkClientException.create(errorMessage);
+        }
+    }
+
+    public static boolean isTotalMessageSizeLargerThanThreshold(int payloadSizeThreshold, long totalMessageSize) {
+        return (totalMessageSize > payloadSizeThreshold);
+    }
+
+    public static int getMsgAttributesSize(Map<String, MessageAttributeValue> msgAttributes) {
+        int totalMsgAttributesSize = 0;
+
+        for (Map.Entry<String, MessageAttributeValue> entry : msgAttributes.entrySet()) {
+            totalMsgAttributesSize += (int) getMessageAttributeSize(entry.getKey(), entry.getValue());
+        }
+
+        return totalMsgAttributesSize;
+    }
+
+    public static long getMessageAttributeSize(String MessageAttributeKey, MessageAttributeValue value) {
+        long messageAttributeSize = Util.getStringSizeInBytes(MessageAttributeKey);
+
+        if (value.dataType() != null) {
+            messageAttributeSize += Util.getStringSizeInBytes(value.dataType());
+        }
+
+        String stringVal = value.stringValue();
+        if (stringVal != null) {
+            messageAttributeSize += Util.getStringSizeInBytes(stringVal);
+        }
+
+        SdkBytes binaryVal = value.binaryValue();
+        if (binaryVal != null) {
+            messageAttributeSize += binaryVal.asByteArray().length;
+        }
+
+        return messageAttributeSize;
+    }
+
+    public static String getS3keyAttribute(Map<String, MessageAttributeValue> messageAttributes) {
+        if (messageAttributes != null && messageAttributes.containsKey(S3_KEY)) {
+            MessageAttributeValue attributeS3KeyValue = messageAttributes.get(S3_KEY);
+            return (attributeS3KeyValue == null) ? null : attributeS3KeyValue.stringValue();
+        }
+        return null;
+    }
+}

--- a/src/main/java/software/amazon/sns/SNSExtendedAsyncClientConfiguration.java
+++ b/src/main/java/software/amazon/sns/SNSExtendedAsyncClientConfiguration.java
@@ -1,0 +1,50 @@
+package software.amazon.sns;
+
+import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.payloadoffloading.PayloadStorageAsyncConfiguration;
+import software.amazon.payloadoffloading.ServerSideEncryptionStrategy;
+
+import static software.amazon.sns.SNSExtendedClientConstants.SNS_DEFAULT_MESSAGE_SIZE;
+
+@NotThreadSafe
+public class SNSExtendedAsyncClientConfiguration extends PayloadStorageAsyncConfiguration {
+
+    public SNSExtendedAsyncClientConfiguration() {
+        this.setPayloadSizeThreshold(SNS_DEFAULT_MESSAGE_SIZE);
+    }
+
+    public SNSExtendedAsyncClientConfiguration(SNSExtendedAsyncClientConfiguration clientConfiguration) {
+        super(clientConfiguration);
+    }
+
+    @Override
+    public SNSExtendedAsyncClientConfiguration withAlwaysThroughS3(boolean alwaysThroughS3) {
+        this.setAlwaysThroughS3(alwaysThroughS3);
+        return this;
+    }
+
+    @Override
+    public SNSExtendedAsyncClientConfiguration withPayloadSupportEnabled(S3AsyncClient s3, String s3BucketName) {
+        this.setPayloadSupportEnabled(s3, s3BucketName);
+        return this;
+    }
+
+    @Override
+    public SNSExtendedAsyncClientConfiguration withServerSideEncryption(ServerSideEncryptionStrategy serverSideEncryptionStrategy) {
+        this.setServerSideEncryptionStrategy(serverSideEncryptionStrategy);
+        return this;
+    }
+
+    @Override
+    public SNSExtendedAsyncClientConfiguration withPayloadSizeThreshold(int payloadSizeThreshold) {
+        this.setPayloadSizeThreshold(payloadSizeThreshold);
+        return this;
+    }
+
+    @Override
+    public SNSExtendedAsyncClientConfiguration withPayloadSupportDisabled() {
+        this.setPayloadSupportDisabled();
+        return this;
+    }
+}

--- a/src/main/java/software/amazon/sns/SNSExtendedClientConfiguration.java
+++ b/src/main/java/software/amazon/sns/SNSExtendedClientConfiguration.java
@@ -4,8 +4,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.payloadoffloading.PayloadStorageConfiguration;
 import software.amazon.payloadoffloading.ServerSideEncryptionStrategy;
 
+import static software.amazon.sns.SNSExtendedClientConstants.SNS_DEFAULT_MESSAGE_SIZE;
+
 public class SNSExtendedClientConfiguration extends PayloadStorageConfiguration {
-    static final int SNS_DEFAULT_MESSAGE_SIZE = 262144;
 
     public SNSExtendedClientConfiguration() {
         super();

--- a/src/main/java/software/amazon/sns/SNSExtendedClientConstants.java
+++ b/src/main/java/software/amazon/sns/SNSExtendedClientConstants.java
@@ -1,0 +1,8 @@
+package software.amazon.sns;
+
+public class SNSExtendedClientConstants {
+
+    public static final int SNS_DEFAULT_MESSAGE_SIZE = 262144;
+    public static final String MULTIPLE_PROTOCOL_MESSAGE_STRUCTURE = "json";
+    public static final String USER_AGENT_HEADER_NAME = "User-Agent";
+}


### PR DESCRIPTION
*Issue #, if available:*
No issue report. This is a feature request from the SQS Extended Client repo community that I decided to also add this feature for SNS as the serverless messaging feature parity. 

*Description of changes:*
Add S3 Async Client support for SNS extended client

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
